### PR TITLE
chore: promote jx3-golang-demo to version 0.0.4

### DIFF
--- a/config-root/namespaces/jx-production/jx-verify/jx-verify-gc-jobs-fhqqh-rb.yaml
+++ b/config-root/namespaces/jx-production/jx-verify/jx-verify-gc-jobs-fhqqh-rb.yaml
@@ -2,10 +2,10 @@
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: jx-verify-gc-jobs-yjesb
+  name: jx-verify-gc-jobs-fhqqh
   annotations:
     meta.helm.sh/release-name: 'jx-verify'
-  namespace: jx-staging
+  namespace: jx-production
   labels:
     gitops.jenkins-x.io/pipeline: 'namespaces'
 roleRef:

--- a/config-root/namespaces/jx-production/jx-verify/jx-verify-gc-jobs-uciot-job.yaml
+++ b/config-root/namespaces/jx-production/jx-verify/jx-verify-gc-jobs-uciot-job.yaml
@@ -2,12 +2,12 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: jx-verify-gc-jobs-8kajq
+  name: jx-verify-gc-jobs-uciot
   annotations:
     kapp.k14s.io/disable-wait: ""
     meta.helm.sh/release-name: 'jx-verify'
   labels:
-    app: jx-verify-gc-jobs-8owec
+    app: jx-verify-gc-jobs-2f7d5
     release: jx-verify
     gitops.jenkins-x.io/pipeline: 'namespaces'
   namespace: jx-production

--- a/config-root/namespaces/jx-staging/jx-verify/jx-verify-gc-jobs-iua3l-rb.yaml
+++ b/config-root/namespaces/jx-staging/jx-verify/jx-verify-gc-jobs-iua3l-rb.yaml
@@ -2,10 +2,10 @@
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: jx-verify-gc-jobs-twrap
+  name: jx-verify-gc-jobs-iua3l
   annotations:
     meta.helm.sh/release-name: 'jx-verify'
-  namespace: jx-production
+  namespace: jx-staging
   labels:
     gitops.jenkins-x.io/pipeline: 'namespaces'
 roleRef:

--- a/config-root/namespaces/jx-staging/jx-verify/jx-verify-gc-jobs-ox3cw-job.yaml
+++ b/config-root/namespaces/jx-staging/jx-verify/jx-verify-gc-jobs-ox3cw-job.yaml
@@ -2,12 +2,12 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: jx-verify-gc-jobs-fzfz8
+  name: jx-verify-gc-jobs-ox3cw
   annotations:
     kapp.k14s.io/disable-wait: ""
     meta.helm.sh/release-name: 'jx-verify'
   labels:
-    app: jx-verify-gc-jobs-a94yf
+    app: jx-verify-gc-jobs-lg9fe
     release: jx-verify
     gitops.jenkins-x.io/pipeline: 'namespaces'
   namespace: jx-staging

--- a/config-root/namespaces/jx-staging/jx3-golang-demo/jx3-golang-demo-jx3-golang-demo-deploy.yaml
+++ b/config-root/namespaces/jx-staging/jx3-golang-demo/jx3-golang-demo-jx3-golang-demo-deploy.yaml
@@ -5,7 +5,7 @@ metadata:
   name: jx3-golang-demo-jx3-golang-demo
   labels:
     draft: draft-app
-    chart: "jx3-golang-demo-0.0.3"
+    chart: "jx3-golang-demo-0.0.4"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   annotations:
     meta.helm.sh/release-name: 'jx3-golang-demo'
@@ -25,11 +25,11 @@ spec:
       serviceAccountName: jx3-golang-demo-jx3-golang-demo
       containers:
         - name: jx3-golang-demo
-          image: "gcr.io/serious-truck-345118/jx3-golang-demo:0.0.3"
+          image: "gcr.io/serious-truck-345118/jx3-golang-demo:0.0.4"
           imagePullPolicy: IfNotPresent
           env:
             - name: VERSION
-              value: 0.0.3
+              value: 0.0.4
           envFrom: null
           ports:
             - name: http

--- a/config-root/namespaces/jx-staging/jx3-golang-demo/jx3-golang-demo-svc.yaml
+++ b/config-root/namespaces/jx-staging/jx3-golang-demo/jx3-golang-demo-svc.yaml
@@ -4,7 +4,7 @@ kind: Service
 metadata:
   name: jx3-golang-demo
   labels:
-    chart: "jx3-golang-demo-0.0.3"
+    chart: "jx3-golang-demo-0.0.4"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   annotations:
     meta.helm.sh/release-name: 'jx3-golang-demo'

--- a/docs/README.md
+++ b/docs/README.md
@@ -31,7 +31,7 @@
 	    </tr>
     <tr>
 	      <td><a href='' title='A Helm chart for Kubernetes'> <img src='https://raw.githubusercontent.com/cdfoundation/artwork/master/jenkinsx/icon/color/jenkinsx-icon-color.png' width='24px' height='24px'> jx3-golang-demo </a></td>
-	      <td>0.0.3</td>
+	      <td>0.0.4</td>
 	      <td></td>
 	      <td></td>
 	    </tr>

--- a/docs/releases.yaml
+++ b/docs/releases.yaml
@@ -33,17 +33,17 @@
     repositoryUrl: https://jenkins-x-charts.github.io/repo
     resourcePath: config-root/namespaces/jx-staging/jx-verify
   - apiVersion: v1
-    appVersion: 0.0.3
+    appVersion: 0.0.4
     description: A Helm chart for Kubernetes
-    firstDeployed: "2022-03-28T21:08:33Z"
+    firstDeployed: "2022-03-28T21:16:42Z"
     icon: https://raw.githubusercontent.com/cdfoundation/artwork/master/jenkinsx/icon/color/jenkinsx-icon-color.png
-    lastDeployed: "2022-03-28T21:08:33Z"
+    lastDeployed: "2022-03-28T21:16:42Z"
     logsUrl: https://console.cloud.google.com/logs/viewer?authuser=1&project=serious-truck-345118&minLogLevel=0&expandAll=false&customFacets=&limitCustomFacetWidth=true&interval=PT1H&resource=k8s_container%2Fcluster_name%2Ftf-jx-prime-tuna%2Fnamespace_name%2Fjx-staging%2Fcontainer_name%2Fjx3-golang-demo&dateRangeUnbound=both
     name: jx3-golang-demo
     repositoryName: dev
     repositoryUrl: http://chartmuseum-jx.34.67.134.91.nip.io
     resourcePath: config-root/namespaces/jx-staging/jx3-golang-demo
-    version: 0.0.3
+    version: 0.0.4
 - namespace: jx
   path: helmfiles/jx/helmfile.yaml
   releases:

--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -15,7 +15,7 @@ releases:
   values:
   - jx-values.yaml
 - chart: dev/jx3-golang-demo
-  version: 0.0.3
+  version: 0.0.4
   name: jx3-golang-demo
   namespace: jx-staging
   values:


### PR DESCRIPTION
chore: promote jx3-golang-demo to version 0.0.4

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge
