### PR TITLE
chore: promote jx3-golang-demo to version 0.0.4

### DIFF
--- a/config-root/namespaces/jx-production/jx-verify/jx-verify-gc-jobs-3ie4w-job.yaml
+++ b/config-root/namespaces/jx-production/jx-verify/jx-verify-gc-jobs-3ie4w-job.yaml
@@ -2,15 +2,15 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: jx-verify-gc-jobs-fzfz8
+  name: jx-verify-gc-jobs-3ie4w
   annotations:
     kapp.k14s.io/disable-wait: ""
     meta.helm.sh/release-name: 'jx-verify'
   labels:
-    app: jx-verify-gc-jobs-a94yf
+    app: jx-verify-gc-jobs-txosd
     release: jx-verify
     gitops.jenkins-x.io/pipeline: 'namespaces'
-  namespace: jx-staging
+  namespace: jx-production
 spec:
   backoffLimit: 1
   completions: 1

--- a/config-root/namespaces/jx-production/jx-verify/jx-verify-gc-jobs-wg94m-rb.yaml
+++ b/config-root/namespaces/jx-production/jx-verify/jx-verify-gc-jobs-wg94m-rb.yaml
@@ -2,10 +2,10 @@
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: jx-verify-gc-jobs-yjesb
+  name: jx-verify-gc-jobs-wg94m
   annotations:
     meta.helm.sh/release-name: 'jx-verify'
-  namespace: jx-staging
+  namespace: jx-production
   labels:
     gitops.jenkins-x.io/pipeline: 'namespaces'
 roleRef:

--- a/config-root/namespaces/jx-production/jx3-golang-demo/jx3-golang-demo-ingress.yaml
+++ b/config-root/namespaces/jx-production/jx3-golang-demo/jx3-golang-demo-ingress.yaml
@@ -1,0 +1,22 @@
+# Source: jx3-golang-demo/templates/ingress.yaml
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    meta.helm.sh/release-name: 'jx3-golang-demo'
+  name: jx3-golang-demo
+  namespace: jx-production
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+spec:
+  rules:
+    - http:
+        paths:
+          - pathType: ImplementationSpecific
+            backend:
+              service:
+                name: jx3-golang-demo
+                port:
+                  number: 80
+      host: jx3-golang-demo-jx-production.34.67.134.91.nip.io

--- a/config-root/namespaces/jx-production/jx3-golang-demo/jx3-golang-demo-jx3-golang-demo-deploy.yaml
+++ b/config-root/namespaces/jx-production/jx3-golang-demo/jx3-golang-demo-jx3-golang-demo-deploy.yaml
@@ -1,0 +1,60 @@
+# Source: jx3-golang-demo/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: jx3-golang-demo-jx3-golang-demo
+  labels:
+    draft: draft-app
+    chart: "jx3-golang-demo-0.0.4"
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  annotations:
+    meta.helm.sh/release-name: 'jx3-golang-demo'
+    wave.pusher.com/update-on-config-change: 'true'
+  namespace: jx-production
+spec:
+  selector:
+    matchLabels:
+      app: jx3-golang-demo-jx3-golang-demo
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        draft: draft-app
+        app: jx3-golang-demo-jx3-golang-demo
+    spec:
+      serviceAccountName: jx3-golang-demo-jx3-golang-demo
+      containers:
+        - name: jx3-golang-demo
+          image: "gcr.io/serious-truck-345118/jx3-golang-demo:0.0.4"
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: VERSION
+              value: 0.0.4
+          envFrom: null
+          ports:
+            - name: http
+              containerPort: 8080
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            initialDelaySeconds: 60
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          resources:
+            limits:
+              cpu: 400m
+              memory: 256Mi
+            requests:
+              cpu: 200m
+              memory: 128Mi
+      terminationGracePeriodSeconds:
+      imagePullSecrets:

--- a/config-root/namespaces/jx-production/jx3-golang-demo/jx3-golang-demo-jx3-golang-demo-sa.yaml
+++ b/config-root/namespaces/jx-production/jx3-golang-demo/jx3-golang-demo-jx3-golang-demo-sa.yaml
@@ -1,0 +1,10 @@
+# Source: jx3-golang-demo/templates/sa.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: jx3-golang-demo-jx3-golang-demo
+  annotations:
+    meta.helm.sh/release-name: 'jx3-golang-demo'
+  namespace: jx-production
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'

--- a/config-root/namespaces/jx-production/jx3-golang-demo/jx3-golang-demo-svc.yaml
+++ b/config-root/namespaces/jx-production/jx3-golang-demo/jx3-golang-demo-svc.yaml
@@ -1,0 +1,20 @@
+# Source: jx3-golang-demo/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: jx3-golang-demo
+  labels:
+    chart: "jx3-golang-demo-0.0.4"
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  annotations:
+    meta.helm.sh/release-name: 'jx3-golang-demo'
+  namespace: jx-production
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+      targetPort: 8080
+      protocol: TCP
+      name: http
+  selector:
+    app: jx3-golang-demo-jx3-golang-demo

--- a/config-root/namespaces/jx-staging/jx-verify/jx-verify-gc-jobs-nzvej-job.yaml
+++ b/config-root/namespaces/jx-staging/jx-verify/jx-verify-gc-jobs-nzvej-job.yaml
@@ -2,15 +2,15 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: jx-verify-gc-jobs-8kajq
+  name: jx-verify-gc-jobs-nzvej
   annotations:
     kapp.k14s.io/disable-wait: ""
     meta.helm.sh/release-name: 'jx-verify'
   labels:
-    app: jx-verify-gc-jobs-8owec
+    app: jx-verify-gc-jobs-fl1es
     release: jx-verify
     gitops.jenkins-x.io/pipeline: 'namespaces'
-  namespace: jx-production
+  namespace: jx-staging
 spec:
   backoffLimit: 1
   completions: 1

--- a/config-root/namespaces/jx-staging/jx-verify/jx-verify-gc-jobs-wzgtq-rb.yaml
+++ b/config-root/namespaces/jx-staging/jx-verify/jx-verify-gc-jobs-wzgtq-rb.yaml
@@ -2,10 +2,10 @@
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: jx-verify-gc-jobs-twrap
+  name: jx-verify-gc-jobs-wzgtq
   annotations:
     meta.helm.sh/release-name: 'jx-verify'
-  namespace: jx-production
+  namespace: jx-staging
   labels:
     gitops.jenkins-x.io/pipeline: 'namespaces'
 roleRef:

--- a/docs/README.md
+++ b/docs/README.md
@@ -21,6 +21,12 @@
 	      <td><a href='https://github.com/jenkins-x-plugins/jx-verify'>source</a></td>
 	    </tr>
     <tr>
+	      <td><a href='' title='A Helm chart for Kubernetes'> <img src='https://raw.githubusercontent.com/cdfoundation/artwork/master/jenkinsx/icon/color/jenkinsx-icon-color.png' width='24px' height='24px'> jx3-golang-demo </a></td>
+	      <td>0.0.4</td>
+	      <td></td>
+	      <td></td>
+	    </tr>
+    <tr>
 		      <td colspan='4'><h3>jx-staging</h3></td>
 		    </tr>
 	    <tr>

--- a/docs/releases.yaml
+++ b/docs/releases.yaml
@@ -16,6 +16,18 @@
     repositoryName: jxgh
     repositoryUrl: https://jenkins-x-charts.github.io/repo
     resourcePath: config-root/namespaces/jx-production/jx-verify
+  - apiVersion: v1
+    appVersion: 0.0.4
+    description: A Helm chart for Kubernetes
+    firstDeployed: "2022-03-28T21:16:49Z"
+    icon: https://raw.githubusercontent.com/cdfoundation/artwork/master/jenkinsx/icon/color/jenkinsx-icon-color.png
+    lastDeployed: "2022-03-28T21:16:49Z"
+    logsUrl: https://console.cloud.google.com/logs/viewer?authuser=1&project=serious-truck-345118&minLogLevel=0&expandAll=false&customFacets=&limitCustomFacetWidth=true&interval=PT1H&resource=k8s_container%2Fcluster_name%2Ftf-jx-prime-tuna%2Fnamespace_name%2Fjx-production%2Fcontainer_name%2Fjx3-golang-demo&dateRangeUnbound=both
+    name: jx3-golang-demo
+    repositoryName: dev
+    repositoryUrl: http://chartmuseum-jx.34.67.134.91.nip.io
+    resourcePath: config-root/namespaces/jx-production/jx3-golang-demo
+    version: 0.0.4
 - namespace: jx-staging
   path: helmfiles/jx-staging/helmfile.yaml
   releases:

--- a/helmfiles/jx-production/helmfile.yaml
+++ b/helmfiles/jx-production/helmfile.yaml
@@ -6,11 +6,17 @@ environments:
 repositories:
 - name: jxgh
   url: https://jenkins-x-charts.github.io/repo
+- name: dev
+  url: http://chartmuseum-jx.34.67.134.91.nip.io
 releases:
 - chart: jxgh/jx-verify
   name: jx-verify
   namespace: jx-production
   values:
   - jx-values.yaml
+- chart: dev/jx3-golang-demo
+  version: 0.0.4
+  name: jx3-golang-demo
+  namespace: jx-production
 templates: {}
 renderedvalues: {}

--- a/helmfiles/jx-production/helmfile.yaml
+++ b/helmfiles/jx-production/helmfile.yaml
@@ -18,5 +18,7 @@ releases:
   version: 0.0.4
   name: jx3-golang-demo
   namespace: jx-production
+  values:
+  - jx-values.yaml
 templates: {}
 renderedvalues: {}


### PR DESCRIPTION
chore: promote jx3-golang-demo to version 0.0.4

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge
