### PR TITLE
chore: promote php-helloworld to version 0.0.1

### DIFF
--- a/config-root/namespaces/jx-production/jx-verify/jx-verify-gc-jobs-lkmc1-job.yaml
+++ b/config-root/namespaces/jx-production/jx-verify/jx-verify-gc-jobs-lkmc1-job.yaml
@@ -2,12 +2,12 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: jx-verify-gc-jobs-0ex46
+  name: jx-verify-gc-jobs-lkmc1
   annotations:
     kapp.k14s.io/disable-wait: ""
     meta.helm.sh/release-name: 'jx-verify'
   labels:
-    app: jx-verify-gc-jobs-n27zu
+    app: jx-verify-gc-jobs-g1s4z
     release: jx-verify
     gitops.jenkins-x.io/pipeline: 'namespaces'
   namespace: jx-production

--- a/config-root/namespaces/jx-production/jx-verify/jx-verify-gc-jobs-rwx6j-rb.yaml
+++ b/config-root/namespaces/jx-production/jx-verify/jx-verify-gc-jobs-rwx6j-rb.yaml
@@ -2,7 +2,7 @@
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: jx-verify-gc-jobs-efgay
+  name: jx-verify-gc-jobs-rwx6j
   annotations:
     meta.helm.sh/release-name: 'jx-verify'
   namespace: jx-production

--- a/config-root/namespaces/jx-production/php-helloworld/php-helloworld-ingress.yaml
+++ b/config-root/namespaces/jx-production/php-helloworld/php-helloworld-ingress.yaml
@@ -1,0 +1,22 @@
+# Source: php-helloworld/templates/ingress.yaml
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    meta.helm.sh/release-name: 'php-helloworld'
+  name: php-helloworld
+  namespace: jx-production
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+spec:
+  rules:
+    - http:
+        paths:
+          - pathType: ImplementationSpecific
+            backend:
+              service:
+                name: php-helloworld
+                port:
+                  number: 80
+      host: php-helloworld-jx-production.34.67.134.91.nip.io

--- a/config-root/namespaces/jx-production/php-helloworld/php-helloworld-php-helloworld-deploy.yaml
+++ b/config-root/namespaces/jx-production/php-helloworld/php-helloworld-php-helloworld-deploy.yaml
@@ -1,0 +1,60 @@
+# Source: php-helloworld/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: php-helloworld-php-helloworld
+  labels:
+    draft: draft-app
+    chart: "php-helloworld-0.0.1"
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  annotations:
+    meta.helm.sh/release-name: 'php-helloworld'
+    wave.pusher.com/update-on-config-change: 'true'
+  namespace: jx-production
+spec:
+  selector:
+    matchLabels:
+      app: php-helloworld-php-helloworld
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        draft: draft-app
+        app: php-helloworld-php-helloworld
+    spec:
+      serviceAccountName: php-helloworld-php-helloworld
+      containers:
+        - name: php-helloworld
+          image: "gcr.io/serious-truck-345118/php-helloworld:0.0.1"
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: VERSION
+              value: 0.0.1
+          envFrom: null
+          ports:
+            - name: http
+              containerPort: 80
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 80
+            initialDelaySeconds: 60
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 80
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          resources:
+            limits:
+              cpu: 400m
+              memory: 256Mi
+            requests:
+              cpu: 200m
+              memory: 128Mi
+      terminationGracePeriodSeconds:
+      imagePullSecrets:

--- a/config-root/namespaces/jx-production/php-helloworld/php-helloworld-php-helloworld-sa.yaml
+++ b/config-root/namespaces/jx-production/php-helloworld/php-helloworld-php-helloworld-sa.yaml
@@ -1,0 +1,10 @@
+# Source: php-helloworld/templates/sa.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: php-helloworld-php-helloworld
+  annotations:
+    meta.helm.sh/release-name: 'php-helloworld'
+  namespace: jx-production
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'

--- a/config-root/namespaces/jx-production/php-helloworld/php-helloworld-svc.yaml
+++ b/config-root/namespaces/jx-production/php-helloworld/php-helloworld-svc.yaml
@@ -1,0 +1,20 @@
+# Source: php-helloworld/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: php-helloworld
+  labels:
+    chart: "php-helloworld-0.0.1"
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  annotations:
+    meta.helm.sh/release-name: 'php-helloworld'
+  namespace: jx-production
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+      targetPort: 80
+      protocol: TCP
+      name: http
+  selector:
+    app: php-helloworld-php-helloworld

--- a/config-root/namespaces/jx-staging/jx-verify/jx-verify-gc-jobs-bmvlt-job.yaml
+++ b/config-root/namespaces/jx-staging/jx-verify/jx-verify-gc-jobs-bmvlt-job.yaml
@@ -2,12 +2,12 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: jx-verify-gc-jobs-upilv
+  name: jx-verify-gc-jobs-bmvlt
   annotations:
     kapp.k14s.io/disable-wait: ""
     meta.helm.sh/release-name: 'jx-verify'
   labels:
-    app: jx-verify-gc-jobs-u8cer
+    app: jx-verify-gc-jobs-4zp2h
     release: jx-verify
     gitops.jenkins-x.io/pipeline: 'namespaces'
   namespace: jx-staging

--- a/config-root/namespaces/jx-staging/jx-verify/jx-verify-gc-jobs-jxp5j-rb.yaml
+++ b/config-root/namespaces/jx-staging/jx-verify/jx-verify-gc-jobs-jxp5j-rb.yaml
@@ -2,7 +2,7 @@
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: jx-verify-gc-jobs-vgqqt
+  name: jx-verify-gc-jobs-jxp5j
   annotations:
     meta.helm.sh/release-name: 'jx-verify'
   namespace: jx-staging

--- a/docs/README.md
+++ b/docs/README.md
@@ -21,6 +21,12 @@
 	      <td><a href='https://github.com/jenkins-x-plugins/jx-verify'>source</a></td>
 	    </tr>
     <tr>
+	      <td><a href='' title='A Helm chart for Kubernetes'> <img src='https://raw.githubusercontent.com/cdfoundation/artwork/master/jenkinsx/icon/color/jenkinsx-icon-color.png' width='24px' height='24px'> php-helloworld </a></td>
+	      <td>0.0.1</td>
+	      <td></td>
+	      <td></td>
+	    </tr>
+    <tr>
 		      <td colspan='4'><h3>jx-staging</h3></td>
 		    </tr>
 	    <tr>

--- a/docs/releases.yaml
+++ b/docs/releases.yaml
@@ -16,6 +16,18 @@
     repositoryName: jxgh
     repositoryUrl: https://jenkins-x-charts.github.io/repo
     resourcePath: config-root/namespaces/jx-production/jx-verify
+  - apiVersion: v1
+    appVersion: 0.0.1
+    description: A Helm chart for Kubernetes
+    firstDeployed: "2022-03-29T01:34:13Z"
+    icon: https://raw.githubusercontent.com/cdfoundation/artwork/master/jenkinsx/icon/color/jenkinsx-icon-color.png
+    lastDeployed: "2022-03-29T01:34:13Z"
+    logsUrl: https://console.cloud.google.com/logs/viewer?authuser=1&project=serious-truck-345118&minLogLevel=0&expandAll=false&customFacets=&limitCustomFacetWidth=true&interval=PT1H&resource=k8s_container%2Fcluster_name%2Ftf-jx-prime-tuna%2Fnamespace_name%2Fjx-production%2Fcontainer_name%2Fphp-helloworld&dateRangeUnbound=both
+    name: php-helloworld
+    repositoryName: dev
+    repositoryUrl: http://chartmuseum-jx.34.67.134.91.nip.io
+    resourcePath: config-root/namespaces/jx-production/php-helloworld
+    version: 0.0.1
 - namespace: jx-staging
   path: helmfiles/jx-staging/helmfile.yaml
   releases:

--- a/helmfiles/jx-production/helmfile.yaml
+++ b/helmfiles/jx-production/helmfile.yaml
@@ -18,5 +18,7 @@ releases:
   version: 0.0.1
   name: php-helloworld
   namespace: jx-production
+  values:
+  - jx-values.yaml
 templates: {}
 renderedvalues: {}

--- a/helmfiles/jx-production/helmfile.yaml
+++ b/helmfiles/jx-production/helmfile.yaml
@@ -6,11 +6,17 @@ environments:
 repositories:
 - name: jxgh
   url: https://jenkins-x-charts.github.io/repo
+- name: dev
+  url: http://chartmuseum-jx.34.67.134.91.nip.io
 releases:
 - chart: jxgh/jx-verify
   name: jx-verify
   namespace: jx-production
   values:
   - jx-values.yaml
+- chart: dev/php-helloworld
+  version: 0.0.1
+  name: php-helloworld
+  namespace: jx-production
 templates: {}
 renderedvalues: {}


### PR DESCRIPTION
chore: promote php-helloworld to version 0.0.1

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge
